### PR TITLE
Update OWNERS and OWNERS_ALIASES by copying from networking repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,7 +21,6 @@ reviewers:
 - markusthoemmes
 - mdemirhan
 - nak3
-- shashwathi
 - tcnghia
 - vagababov
 - yanweiguo

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,28 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- technical-oversight-committee
-- dprotaso
+# TOC
+- evankanderson
+- grantr
+- markusthoemmes
 - mattmoor
-- n3wscott
-- vaikas-google
-- vaikas
+- tcnghia
+# Networking Approvers
+- JRBANCEL
+- mdemirhan
+- nak3
+- vagababov
+- ZhiminXiang
+
+# Networking Reviewers
+reviewers:
+- andrew-su
+- JRBANCEL
+- markusthoemmes
+- mdemirhan
+- nak3
+- shashwathi
+- tcnghia
+- vagababov
+- yanweiguo
+- ZhiminXiang

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,10 +8,4 @@ aliases:
   - chizhg
   - steuhs
   - yt3liu
-  technical-oversight-committee:
-  - evankanderson
-  - grantr
-  - markusthoemmes
-  - mattmoor
-  - tcnghia
 


### PR DESCRIPTION
This patch updates OWNERS and OWNERS_ALIASES files by just copying
from networking repo https://github.com/knative/networking.

Please also refer to https://github.com/knative/community/issues/389.

/cc @tcnghia @ZhiminXiang 