### PR TITLE
Add IsHTTPRouteReady status check

### DIFF
--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -1073,7 +1073,7 @@ func WaitForHTTPRouteState(ctx context.Context, client *test.GatewayAPIClients, 
 func IsHTTPRouteReady(r *gatewayv1alpha1.HTTPRoute) (bool, error) {
 	for _, gw := range r.Status.Gateways {
 		for _, condition := range gw.Conditions {
-			if condition.Type == "Admitted" && condition.Status != metav1.ConditionTrue {
+			if condition.Type == string(gatewayv1alpha1.ConditionRouteAdmitted) && condition.Status != metav1.ConditionTrue {
 				return false, nil
 			}
 		}

--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -1073,12 +1073,11 @@ func WaitForHTTPRouteState(ctx context.Context, client *test.GatewayAPIClients, 
 func IsHTTPRouteReady(r *gatewayv1alpha1.HTTPRoute) (bool, error) {
 	for _, gw := range r.Status.Gateways {
 		for _, condition := range gw.Conditions {
-			if condition.Type == "true" && condition.Status == metav1.ConditionTrue {
-				return true, nil
+			if condition.Type == "Admitted" && condition.Status != metav1.ConditionTrue {
+				return false, nil
 			}
 		}
 	}
-	// TODO: Istio still does not update HTTPRoute status.
 	return true, nil
 }
 

--- a/test/conformance/ingressv2/util_test.go
+++ b/test/conformance/ingressv2/util_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,6 @@ package ingress
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
@@ -119,14 +118,13 @@ func TestIsHTTPRouteReady(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			httpRoute := &gatewayv1alpha1.HTTPRoute{
 				Status: gatewayv1alpha1.HTTPRouteStatus{
-					RouteStatus: gatewayv1alpha1.RouteStatus{test.gatewayStatus},
+					RouteStatus: gatewayv1alpha1.RouteStatus{Gateways: test.gatewayStatus},
 				},
 			}
 			got, _ := IsHTTPRouteReady(httpRoute)
-			if !cmp.Equal(got, test.expect) {
+			if got != test.expect {
 				t.Errorf("Got = %v, want = %v", got, test.expect)
 			}
 		})

--- a/test/conformance/ingressv2/util_test.go
+++ b/test/conformance/ingressv2/util_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func TestIsHTTPRouteReady(t *testing.T) {
+	tests := []struct {
+		name          string
+		expect        bool
+		gatewayStatus []gatewayv1alpha1.RouteGatewayStatus
+	}{
+		{
+			name: "Zero gateway - it does not have status condition",
+		}, {
+			name:   "One gateway - it has Admitted condition true",
+			expect: true,
+			gatewayStatus: []gatewayv1alpha1.RouteGatewayStatus{{
+				GatewayRef: gatewayv1alpha1.GatewayReference{Name: "foo", Namespace: "foo"},
+				Conditions: []metav1.Condition{{
+					Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+					Status: metav1.ConditionTrue,
+				}},
+			}},
+		}, {
+			name: "One gateway - it has Admitted condition false",
+			gatewayStatus: []gatewayv1alpha1.RouteGatewayStatus{{
+				GatewayRef: gatewayv1alpha1.GatewayReference{Name: "foo", Namespace: "foo"},
+				Conditions: []metav1.Condition{{
+					Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+					Status: metav1.ConditionFalse,
+				}},
+			}},
+		}, {
+			name: "One gateway - it does not have Admitted condition",
+			gatewayStatus: []gatewayv1alpha1.RouteGatewayStatus{{
+				GatewayRef: gatewayv1alpha1.GatewayReference{Name: "foo", Namespace: "foo"},
+			}},
+		}, {
+			name:   "Two gateways - both have Admitted condition true",
+			expect: true,
+			gatewayStatus: []gatewayv1alpha1.RouteGatewayStatus{
+				{
+					GatewayRef: gatewayv1alpha1.GatewayReference{Name: "foo", Namespace: "foo"},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				}, {
+					GatewayRef: gatewayv1alpha1.GatewayReference{Name: "bar", Namespace: "bar"},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+		}, {
+			name: "Two gateways - one has Admitted condition false",
+			gatewayStatus: []gatewayv1alpha1.RouteGatewayStatus{
+				{
+					GatewayRef: gatewayv1alpha1.GatewayReference{Name: "foo", Namespace: "foo"},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+							Status: metav1.ConditionFalse,
+						},
+					},
+				}, {
+					GatewayRef: gatewayv1alpha1.GatewayReference{Name: "bar", Namespace: "bar"},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+		}, {
+			name: "Two gateways - one does not have Admitted condition",
+			gatewayStatus: []gatewayv1alpha1.RouteGatewayStatus{
+				{
+					GatewayRef: gatewayv1alpha1.GatewayReference{Name: "foo", Namespace: "foo"},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1alpha1.ConditionRouteAdmitted),
+							Status: metav1.ConditionFalse,
+						},
+					},
+				}, {
+					GatewayRef: gatewayv1alpha1.GatewayReference{Name: "bar", Namespace: "bar"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			httpRoute := &gatewayv1alpha1.HTTPRoute{
+				Status: gatewayv1alpha1.HTTPRouteStatus{
+					RouteStatus: gatewayv1alpha1.RouteStatus{test.gatewayStatus},
+				},
+			}
+			got, _ := IsHTTPRouteReady(httpRoute)
+			if !cmp.Equal(got, test.expect) {
+				t.Errorf("Got = %v, want = %v", got, test.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch enables `IsHTTPRouteReady()` function to verify HTTPRoute status.
Istio and Contour both support the status now.

/cc @markusthoemmes @tcnghia @ZhiminXiang 

Fix https://github.com/knative-sandbox/net-ingressv2/issues/30