### PR TITLE
Wait for contour-operator deployment instead of pod

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -159,8 +159,8 @@ jobs:
         # Deploy Contour
         ./third_party/contour-head/install-operator.sh
 
-        # wait for operator pod to be up
-        kubectl wait pod --for=condition=Ready --timeout=120s -n "contour-operator" -l '!job-name'
+        # wait for operator deployment to be Available
+        kubectl wait deploy --for=condition=Available --timeout=120s -n "contour-operator" -l '!job-name'
 
         # TODO: deploy gateway-internal.yaml when visibility test could be supported.
         ko resolve -f ./third_party/contour-head/gateway/gateway-external.yaml | \


### PR DESCRIPTION
kind-e2e waits pods to be up by `kubectl wait pod
--for=condition=Ready -n "contour-operator"` but it gets error when
any pods are not created yet in the namespace.
The script is failing sometimes due to the issue:
e.g. https://github.com/knative-sandbox/net-ingressv2/runs/2418620924?check_suite_focus=true

Hence, This patch changes it to wait Deployment to be Available.

/cc @markusthoemmes @tcnghia @ZhiminXiang 