### PR TITLE
Add TestPercentage to contour

### DIFF
--- a/test/conformance/ingressv2/run.go
+++ b/test/conformance/ingressv2/run.go
@@ -45,6 +45,7 @@ var contourStableTests = map[string]func(t *testing.T){
 	"headers/pre-split":            TestPreSplitSetHeaders,
 	"headers/post-split":           TestPostSplitSetHeaders,
 	"dispatch/path":                TestPath,
+	"dispatch/percentage":          TestPercentage,
 	"dispatch/path_and_percentage": TestPathAndPercentageSplit,
 	"dispatch/rule":                TestRule,
 	"hosts/multiple":               TestMultipleHosts,


### PR DESCRIPTION
This patch adds TestPercentage to contour test.
Contour implemented it a few days ago by https://github.com/projectcontour/contour/commit/b155ccc1da240c08ceabd2824b40793cb8a705bf

/cc @markusthoemmes @tcnghia @ZhiminXiang 