### PR TITLE
Update Gateway namespaces

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -171,9 +171,9 @@ jobs:
 
         # This tells the tests what namespace to look in for our kingress LB.
         echo "GATEWAY_OVERRIDE=envoy" >> $GITHUB_ENV
-        echo "GATEWAY_NAMESPACE_OVERRIDE=contour-external" >> $GITHUB_ENV
+        echo "GATEWAY_NAMESPACE_OVERRIDE=test-gateway" >> $GITHUB_ENV
         echo "LOCAL_GATEWAY_OVERRIDE=envoy" >> $GITHUB_ENV
-        echo "LOCAL_GATEWAY_NAMESPACE_OVERRIDE=contour-internal" >> $GITHUB_ENV
+        echo "LOCAL_GATEWAY_NAMESPACE_OVERRIDE=test-local-gateway" >> $GITHUB_ENV
 
     - name: Upload Test Images
       run: |

--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -72,7 +72,7 @@ var dialBackoff = wait.Backoff{
 var testGateway = gatewayv1alpha1.RouteGateways{
 	Allow: gatewayv1alpha1.GatewayAllowFromList,
 	GatewayRefs: []gatewayv1alpha1.GatewayReference{{
-		Namespace: "knative-serving",
+		Namespace: "test-gateway",
 		Name:      "test-gateway",
 	}},
 }
@@ -80,7 +80,7 @@ var testGateway = gatewayv1alpha1.RouteGateways{
 var testLocalGateway = gatewayv1alpha1.RouteGateways{
 	Allow: gatewayv1alpha1.GatewayAllowFromList,
 	GatewayRefs: []gatewayv1alpha1.GatewayReference{{
-		Namespace: "knative-serving",
+		Namespace: "test-local-gateway",
 		Name:      "test-local-gateway",
 	}},
 }

--- a/test/conformance/ingressv2/visibility.go
+++ b/test/conformance/ingressv2/visibility.go
@@ -48,7 +48,7 @@ func TestVisibility(t *testing.T) {
 	}
 
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
-		Gateways:  testLocalGateway, // Ths field is not working on Contour - https://github.com/projectcontour/contour/issues/3615
+		Gateways:  testLocalGateway,
 		Hostnames: []gwv1alpha1.Hostname{privateHostNames["fqdn"], privateHostNames["short"], privateHostNames["shortest"]},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
@@ -145,7 +145,7 @@ func TestVisibilitySplit(t *testing.T) {
 	// Create a simple Ingress over the 10 Services.
 	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, nettest.NetworkingFlags.ClusterSuffix)
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
-		Gateways:  testLocalGateway, // Ths field is not working on Contour - https://github.com/projectcontour/contour/issues/3615
+		Gateways:  testLocalGateway,
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(privateHostName)},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: backends,
@@ -247,7 +247,7 @@ func TestVisibilityPath(t *testing.T) {
 	name := test.ObjectNameForTest(t)
 	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, nettest.NetworkingFlags.ClusterSuffix)
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
-		Gateways:  testLocalGateway, // Ths is not working on Contour - https://github.com/projectcontour/contour/issues/3615
+		Gateways:  testLocalGateway,
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(privateHostName)},
 		Rules: []gwv1alpha1.HTTPRouteRule{
 			{

--- a/third_party/contour-head/gateway/gateway-external.yaml
+++ b/third_party/contour-head/gateway/gateway-external.yaml
@@ -17,6 +17,13 @@ kind: Namespace
 metadata:
   labels:
     control-plane: contour-operator
+  name: test-gateway
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: contour-operator
   name: contour-external
 ---
 apiVersion: operator.projectcontour.io/v1alpha1
@@ -27,7 +34,7 @@ metadata:
 spec:
   gatewayClassRef: contour-external-gatewayclass
   namespace:
-    name: contour-external
+    name: test-gateway
   ingressClassName: contour-external
   networkPublishing:
     envoy:
@@ -49,8 +56,8 @@ spec:
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: contour-external
-  namespace: contour-external
+  name: test-gateway
+  namespace: test-gateway
 spec:
   gatewayClassName: contour-external-gatewayclass
   listeners:

--- a/third_party/contour-head/gateway/gateway-internal.yaml
+++ b/third_party/contour-head/gateway/gateway-internal.yaml
@@ -17,6 +17,13 @@ kind: Namespace
 metadata:
   labels:
     control-plane: contour-operator
+  name: test-local-gateway
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: contour-operator
   name: contour-internal
 ---
 apiVersion: operator.projectcontour.io/v1alpha1
@@ -27,7 +34,7 @@ metadata:
 spec:
   gatewayClassRef: contour-internal-gatewayclass
   namespace:
-    name: contour-internal
+    name: test-local-gateway
   ingressClassName: contour-internal
   networkPublishing:
     envoy:
@@ -49,8 +56,8 @@ spec:
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: contour-internal
-  namespace: contour-internal
+  name: test-local-gateway
+  namespace: test-local-gateway
 spec:
   gatewayClassName: contour-internal-gatewayclass
   listeners:

--- a/third_party/istio-head/gateway/300-gateway.yaml
+++ b/third_party/istio-head/gateway/300-gateway.yaml
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-gateway
+---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: test-gateway
-  namespace: knative-serving
+  namespace: test-gateway
 spec:
   gatewayClassName: istio
   listeners:


### PR DESCRIPTION
Since https://github.com/projectcontour/contour/issues/3615 was fixed,
Contour takes care of the namespace of Gateway.
So this patch moves external and internal Gateway moves to
`test-gateway` namespace and `test-local-gateway` namespace.

side note: Contour pod and Gateway must be deployed in the same
namespace due to https://github.com/projectcontour/contour-operator/issues/343.
(It also means that two Gateways cannot be deployed in the same namespace.)

/cc @markusthoemmes @ZhiminXiang @tcnghia 