### PR TITLE
Update DEVELOPMENT.md

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -136,8 +136,8 @@ jobs:
       run: |
         set -o pipefail
 
-        # service-apis CRD must be installed before Istio.
-        kubectl apply -k 'github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.2.0'
+        # gateway-api CRD must be installed before Istio.
+        kubectl apply -k 'github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.2.0'
 
         # Replace cluster.local with random suffix.
         sed -ie "s/cluster\.local/${CLUSTER_SUFFIX}/g" third_party/istio-head/istio-kind-no-mesh.yaml

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![GoDoc](https://godoc.org/knative.dev/net-ingressv2?status.svg)](https://godoc.org/knative.dev/net-ingressv2)
 [![Go Report Card](https://goreportcard.com/badge/knative/net-ingressv2)](https://goreportcard.com/report/knative/net-ingressv2)
 
-Knative `net-ingressv2` defines a service-apis(Ingress v2) controller for
-migration.
+This repository contains [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
+conformance tests.
+The tests are same with [Knative networking](https://github.com/knative/networking/tree/main/test/conformance)
+but against Gateway API resources without Knative Ingress.
 
 To learn more about Knative, please visit our
 [Knative docs](https://github.com/knative/docs) repository.


### PR DESCRIPTION
As net-ingressv2 stops creating controller but started hosting
conformance tests, README and DEVELOPMENT guides also needs to be
updated for that.

Fix https://github.com/knative-sandbox/net-ingressv2/issues/50