### PR TITLE
Use common function to get port pointer

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,7 +112,7 @@ GATEWAY_OVERRIDE=istio-ingressgateway
 GATEWAY_NAMESPACE_OVERRIDE=istio-system
 IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 
-go test -v -tags=e2e -count=1  ./test/conformance/ingressv2/  -run "TestIngressConformance/hosts/basics" \
+go test -v -tags=e2e -count=1  ./test/conformance/ingressv2/  -run "TestIngressConformance/basics" \
   --ingressClass=istio \
   --ingressendpoint="${IPS[0]}"
 ```

--- a/test/conformance/ingressv2/basic.go
+++ b/test/conformance/ingressv2/basic.go
@@ -31,14 +31,13 @@ func TestBasics(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
 		Gateways:  testGateway,
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(name + ".example.com")},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}},
@@ -54,14 +53,13 @@ func TestBasicsHTTP2(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameH2C)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
 		Gateways:  testGateway,
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(name + ".example.com")},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}},

--- a/test/conformance/ingressv2/grpc.go
+++ b/test/conformance/ingressv2/grpc.go
@@ -42,7 +42,6 @@ func TestGRPC(t *testing.T) {
 
 	const suffix = "- pong"
 	name, port, _ := CreateGRPCService(ctx, t, clients, suffix)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	domain := name + ".example.com"
 
@@ -52,7 +51,7 @@ func TestGRPC(t *testing.T) {
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(domain)},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}}})
@@ -95,11 +94,9 @@ func TestGRPCSplit(t *testing.T) {
 
 	const suffixBlue = "- blue"
 	blueName, bluePort, _ := CreateGRPCService(ctx, t, clients, suffixBlue)
-	bluePortNum := gwv1alpha1.PortNumber(bluePort)
 
 	const suffixGreen = "- green"
 	greenName, greenPort, _ := CreateGRPCService(ctx, t, clients, suffixGreen)
-	greenPortNum := gwv1alpha1.PortNumber(greenPort)
 
 	// The suffixes we expect to see.
 	want := sets.NewString(suffixBlue, suffixGreen)
@@ -113,11 +110,11 @@ func TestGRPCSplit(t *testing.T) {
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{
 				{
-					Port:        &bluePortNum,
+					Port:        portNumPtr(bluePort),
 					ServiceName: &blueName,
 					Weight:      pointer.Int32Ptr(1),
 				}, {
-					Port:        &greenPortNum,
+					Port:        portNumPtr(greenPort),
 					ServiceName: &greenName,
 					Weight:      pointer.Int32Ptr(1),
 				},

--- a/test/conformance/ingressv2/headers.go
+++ b/test/conformance/ingressv2/headers.go
@@ -40,7 +40,6 @@ func TestTagHeaders(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	const (
 		tagName           = "the-tag"
@@ -55,7 +54,7 @@ func TestTagHeaders(t *testing.T) {
 		Rules: []gwv1alpha1.HTTPRouteRule{
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &portNum,
+					Port:        portNumPtr(port),
 					ServiceName: &name,
 				}},
 				Matches: []gwv1alpha1.HTTPRouteMatch{{
@@ -73,7 +72,7 @@ func TestTagHeaders(t *testing.T) {
 			},
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &portNum,
+					Port:        portNumPtr(port),
 					ServiceName: &name,
 				}},
 				Filters: []gwv1alpha1.HTTPRouteFilter{{
@@ -141,7 +140,6 @@ func TestPreSplitSetHeaders(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	const headerName = "Foo-Bar-Baz"
 
@@ -150,7 +148,7 @@ func TestPreSplitSetHeaders(t *testing.T) {
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(name + ".example.com")},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 			Filters: []gwv1alpha1.HTTPRouteFilter{{
@@ -208,11 +206,10 @@ func TestPostSplitSetHeaders(t *testing.T) {
 	names := make(sets.String, splits)
 	for i := 0; i < splits; i++ {
 		name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-		portNum := gwv1alpha1.PortNumber(port)
 
 		forwards = append(forwards,
 			gwv1alpha1.HTTPRouteForwardTo{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 				Weight:      pointer.Int32Ptr(100 / splits),
 				Filters: []gwv1alpha1.HTTPRouteFilter{{

--- a/test/conformance/ingressv2/hosts.go
+++ b/test/conformance/ingressv2/hosts.go
@@ -31,7 +31,6 @@ func TestMultipleHosts(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	hosts := []gwv1alpha1.Hostname{
 		"foo.com",
@@ -52,7 +51,7 @@ func TestMultipleHosts(t *testing.T) {
 		Hostnames: hosts,
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}},

--- a/test/conformance/ingressv2/path.go
+++ b/test/conformance/ingressv2/path.go
@@ -37,18 +37,14 @@ func TestPath(t *testing.T) {
 
 	// For /foo
 	fooName, fooPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	fooPortNum := gwv1alpha1.PortNumber(fooPort)
 
 	// For /bar
 	barName, barPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	barPortNum := gwv1alpha1.PortNumber(barPort)
 
 	// For /baz
 	bazName, bazPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	bazPortNum := gwv1alpha1.PortNumber(bazPort)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
@@ -59,7 +55,7 @@ func TestPath(t *testing.T) {
 		Rules: []gwv1alpha1.HTTPRouteRule{
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &fooPortNum,
+					Port:        portNumPtr(fooPort),
 					ServiceName: &fooName,
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
@@ -79,7 +75,7 @@ func TestPath(t *testing.T) {
 			},
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &barPortNum,
+					Port:        portNumPtr(barPort),
 					ServiceName: &barName,
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
@@ -99,7 +95,7 @@ func TestPath(t *testing.T) {
 			},
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &bazPortNum,
+					Port:        portNumPtr(bazPort),
 					ServiceName: &bazName,
 					// Append different headers to each split, which lets us identify
 					// which backend we hit.
@@ -119,7 +115,7 @@ func TestPath(t *testing.T) {
 			},
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &portNum,
+					Port:        portNumPtr(port),
 					ServiceName: &name,
 				}},
 				// Append different headers to each split, which lets us identify
@@ -164,13 +160,10 @@ func TestPathAndPercentageSplit(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	fooName, fooPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	fooPortNum := gwv1alpha1.PortNumber(fooPort)
 
 	barName, barPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	barPortNum := gwv1alpha1.PortNumber(barPort)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	// Use a post-split injected header to establish which split we are sending traffic to.
 	const headerName = "Which-Backend"
@@ -182,7 +175,7 @@ func TestPathAndPercentageSplit(t *testing.T) {
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{
 					{
-						Port:        &fooPortNum,
+						Port:        portNumPtr(fooPort),
 						ServiceName: &fooName,
 						Weight:      pointer.Int32Ptr(1),
 						// Append different headers to each split, which lets us identify
@@ -195,7 +188,7 @@ func TestPathAndPercentageSplit(t *testing.T) {
 						}},
 					},
 					{
-						Port:        &barPortNum,
+						Port:        portNumPtr(barPort),
 						ServiceName: &barName,
 						Weight:      pointer.Int32Ptr(1),
 						// Append different headers to each split, which lets us identify
@@ -217,7 +210,7 @@ func TestPathAndPercentageSplit(t *testing.T) {
 			},
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &portNum,
+					Port:        portNumPtr(port),
 					ServiceName: &name,
 					Weight:      pointer.Int32Ptr(1),
 				}},

--- a/test/conformance/ingressv2/percentage.go
+++ b/test/conformance/ingressv2/percentage.go
@@ -46,10 +46,9 @@ func TestPercentage(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		weight := percent
 		name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-		portNum := gwv1alpha1.PortNumber(port)
 		backends = append(backends, gwv1alpha1.HTTPRouteForwardTo{
 			ServiceName: &name,
-			Port:        &portNum,
+			Port:        portNumPtr(port),
 			Weight:      &weight,
 			// Append different headers to each split, which lets us identify
 			// which backend we hit.

--- a/test/conformance/ingressv2/rewrite.go
+++ b/test/conformance/ingressv2/rewrite.go
@@ -31,7 +31,6 @@ func TestRewriteHost(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	privateServiceName := test.ObjectNameForTest(t)
 	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc.cluster.local"
@@ -43,7 +42,7 @@ func TestRewriteHost(t *testing.T) {
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(privateHostName)},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}},
@@ -61,15 +60,13 @@ func TestRewriteHost(t *testing.T) {
 		gwv1alpha1.Hostname(name + "." + "vanity.isalsomy.number"),
 	}
 
-	portNumIng := gwv1alpha1.PortNumber(80)
-
 	// Now create a RewriteHost ingress to point a custom Host at the Service
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
 		Gateways:  testGateway,
 		Hostnames: hosts,
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNumIng,
+				Port:        portNumPtr(80),
 				ServiceName: &privateServiceName,
 			}},
 			Filters: []gwv1alpha1.HTTPRouteFilter{

--- a/test/conformance/ingressv2/rule.go
+++ b/test/conformance/ingressv2/rule.go
@@ -35,9 +35,7 @@ func TestRule(t *testing.T) {
 	const headerName = "Foo-Bar-Baz"
 
 	fooName, fooPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	fooPortNum := gwv1alpha1.PortNumber(fooPort)
 	barName, barPort, _ := CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
-	barPortNum := gwv1alpha1.PortNumber(barPort)
 
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
 		Gateways:  testGateway,
@@ -45,7 +43,7 @@ func TestRule(t *testing.T) {
 		Rules: []gwv1alpha1.HTTPRouteRule{
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &fooPortNum,
+					Port:        portNumPtr(fooPort),
 					ServiceName: &fooName,
 				}},
 				Matches: []gwv1alpha1.HTTPRouteMatch{{
@@ -68,7 +66,7 @@ func TestRule(t *testing.T) {
 			},
 			{
 				ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-					Port:        &barPortNum,
+					Port:        portNumPtr(barPort),
 					ServiceName: &barName,
 				}},
 				Matches: []gwv1alpha1.HTTPRouteMatch{{

--- a/test/conformance/ingressv2/timeout.go
+++ b/test/conformance/ingressv2/timeout.go
@@ -33,7 +33,6 @@ func TestTimeout(t *testing.T) {
 	ctx, clients := context.Background(), test.Setup(t)
 
 	name, port, _ := CreateTimeoutService(ctx, t, clients)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	// Create a simple HTTPRoute over the Service.
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
@@ -41,7 +40,7 @@ func TestTimeout(t *testing.T) {
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(name + ".example.com")},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}},

--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -71,6 +71,11 @@ func gatewayAllowTypePtr(val gatewayv1alpha1.GatewayAllowType) *gatewayv1alpha1.
 	return &val
 }
 
+func portNumPtr(port int) *gatewayv1alpha1.PortNumber {
+	pn := gatewayv1alpha1.PortNumber(port)
+	return &pn
+}
+
 var rootCAs = x509.NewCertPool()
 
 var dialBackoff = wait.Backoff{

--- a/test/conformance/ingressv2/websocket.go
+++ b/test/conformance/ingressv2/websocket.go
@@ -41,7 +41,6 @@ func TestWebsocket(t *testing.T) {
 
 	const suffix = "- pong"
 	name, port, _ := CreateWebsocketService(ctx, t, clients, suffix)
-	portNum := gwv1alpha1.PortNumber(port)
 
 	domain := name + ".example.com"
 
@@ -51,7 +50,7 @@ func TestWebsocket(t *testing.T) {
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(domain)},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &portNum,
+				Port:        portNumPtr(port),
 				ServiceName: &name,
 			}},
 		}}})
@@ -87,11 +86,9 @@ func TestWebsocketSplit(t *testing.T) {
 
 	const suffixBlue = "- blue"
 	blueName, bluePort, _ := CreateWebsocketService(ctx, t, clients, suffixBlue)
-	bluePortNum := gwv1alpha1.PortNumber(bluePort)
 
 	const suffixGreen = "- green"
 	greenName, greenPort, _ := CreateWebsocketService(ctx, t, clients, suffixGreen)
-	greenPortNum := gwv1alpha1.PortNumber(greenPort)
 
 	// The suffixes we expect to see.
 	want := sets.NewString(suffixBlue, suffixGreen)
@@ -104,11 +101,11 @@ func TestWebsocketSplit(t *testing.T) {
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(domain)},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
-				Port:        &bluePortNum,
+				Port:        portNumPtr(bluePort),
 				ServiceName: &blueName,
 				Weight:      pointer.Int32Ptr(1),
 			}, {
-				Port:        &greenPortNum,
+				Port:        portNumPtr(greenPort),
 				ServiceName: &greenName,
 				Weight:      pointer.Int32Ptr(1),
 			}},


### PR DESCRIPTION
This patch adds a new function `portNumPtr()` to get port pointer.

/kind cleanup