### PR TITLE
Add visibility test for Istio

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -142,6 +142,7 @@ jobs:
         # Replace cluster.local with random suffix.
         sed -ie "s/cluster\.local/${CLUSTER_SUFFIX}/g" third_party/istio-head/istio-kind-no-mesh.yaml
         sed -ie "s/cluster\.local/${CLUSTER_SUFFIX}/g" third_party/istio-head/gateway/300-gateway.yaml
+        sed -ie "s/cluster\.local/${CLUSTER_SUFFIX}/g" third_party/istio-head/gateway/300-gateway-local.yaml
 
         # Deploy Istio
         ./third_party/istio-head/install-istio.sh istio-kind-no-mesh.yaml

--- a/test/conformance/ingressv2/run.go
+++ b/test/conformance/ingressv2/run.go
@@ -38,6 +38,7 @@ var istioStableTests = map[string]func(t *testing.T){
 	"websocket/split":              TestWebsocketSplit,
 	"grpc":                         TestGRPC,
 	"grpc/split":                   TestGRPCSplit,
+	"visibility":                   TestVisibility,
 }
 
 var contourStableTests = map[string]func(t *testing.T){

--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -87,19 +87,11 @@ var dialBackoff = wait.Backoff{
 }
 
 var testGateway = &gatewayv1alpha1.RouteGateways{
-	Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowFromList),
-	GatewayRefs: []gatewayv1alpha1.GatewayReference{{
-		Namespace: "istio-system",
-		Name:      "test-gateway",
-	}},
+	Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
 }
 
 var testLocalGateway = &gatewayv1alpha1.RouteGateways{
-	Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowFromList),
-	GatewayRefs: []gatewayv1alpha1.GatewayReference{{
-		Namespace: "istio-system",
-		Name:      "test-local-gateway",
-	}},
+	Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
 }
 
 // gatewayLabel is added to HTTPRoute. The external gateway selects the generated HTTPRoute by this label.

--- a/test/conformance/ingressv2/util.go
+++ b/test/conformance/ingressv2/util.go
@@ -89,7 +89,7 @@ var dialBackoff = wait.Backoff{
 var testGateway = &gatewayv1alpha1.RouteGateways{
 	Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowFromList),
 	GatewayRefs: []gatewayv1alpha1.GatewayReference{{
-		Namespace: "knative-serving",
+		Namespace: "istio-system",
 		Name:      "test-gateway",
 	}},
 }
@@ -97,7 +97,7 @@ var testGateway = &gatewayv1alpha1.RouteGateways{
 var testLocalGateway = &gatewayv1alpha1.RouteGateways{
 	Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowFromList),
 	GatewayRefs: []gatewayv1alpha1.GatewayReference{{
-		Namespace: "knative-serving",
+		Namespace: "istio-system",
 		Name:      "test-local-gateway",
 	}},
 }
@@ -912,7 +912,7 @@ func getClusterIngress() (string, string) {
 	if gatewayNsOverride := os.Getenv("LOCAL_GATEWAY_NAMESPACE_OVERRIDE"); gatewayNsOverride != "" {
 		namespace = gatewayNsOverride
 	}
-	name := "istio-ingressgateway"
+	name := "knative-local-gateway"
 	if gatewayOverride := os.Getenv("LOCAL_GATEWAY_OVERRIDE"); gatewayOverride != "" {
 		name = gatewayOverride
 	}

--- a/test/conformance/ingressv2/visibility.go
+++ b/test/conformance/ingressv2/visibility.go
@@ -48,7 +48,7 @@ func TestVisibility(t *testing.T) {
 	}
 
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
-		Gateways:  testLocalGateway, // Ths field is not working on Contour - https://github.com/projectcontour/contour/issues/3615
+		Gateways:  testLocalGateway,
 		Hostnames: []gwv1alpha1.Hostname{privateHostNames["fqdn"], privateHostNames["short"], privateHostNames["shortest"]},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: []gwv1alpha1.HTTPRouteForwardTo{{
@@ -144,7 +144,7 @@ func TestVisibilitySplit(t *testing.T) {
 	// Create a simple Ingress over the 10 Services.
 	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, nettest.NetworkingFlags.ClusterSuffix)
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
-		Gateways:  testLocalGateway, // Ths field is not working on Contour - https://github.com/projectcontour/contour/issues/3615
+		Gateways:  testLocalGateway,
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(privateHostName)},
 		Rules: []gwv1alpha1.HTTPRouteRule{{
 			ForwardTo: backends,
@@ -241,7 +241,7 @@ func TestVisibilityPath(t *testing.T) {
 	name := test.ObjectNameForTest(t)
 	privateHostName := fmt.Sprintf("%s.%s.svc.%s", name, test.ServingNamespace, nettest.NetworkingFlags.ClusterSuffix)
 	_, client, _ := CreateHTTPRouteReady(ctx, t, clients, gwv1alpha1.HTTPRouteSpec{
-		Gateways:  testLocalGateway, // Ths is not working on Contour - https://github.com/projectcontour/contour/issues/3615
+		Gateways:  testLocalGateway,
 		Hostnames: []gwv1alpha1.Hostname{gwv1alpha1.Hostname(privateHostName)},
 		Rules: []gwv1alpha1.HTTPRouteRule{
 			{

--- a/third_party/contour-head/gateway/gateway-external.yaml
+++ b/third_party/contour-head/gateway/gateway-external.yaml
@@ -19,6 +19,15 @@ metadata:
     control-plane: contour-operator
   name: contour-external
 ---
+# workaround of net-contour/issues/549
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: contour-external
+  namespace: contour-external
+spec:
+  controller: example.com/ingress-controller
+---
 apiVersion: operator.projectcontour.io/v1alpha1
 kind: Contour
 metadata:

--- a/third_party/contour-head/gateway/gateway-internal.yaml
+++ b/third_party/contour-head/gateway/gateway-internal.yaml
@@ -19,6 +19,15 @@ metadata:
     control-plane: contour-operator
   name: contour-internal
 ---
+# workaround of net-contour/issues/549
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: contour-internal
+  namespace: contour-internal
+spec:
+  controller: example.com/ingress-controller
+---
 apiVersion: operator.projectcontour.io/v1alpha1
 kind: Contour
 metadata:

--- a/third_party/istio-head/gateway/203-local-gateway.yaml
+++ b/third_party/istio-head/gateway/203-local-gateway.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A cluster local gateway to allow pods outside of the mesh to access
+# Services and Routes not exposing through an ingress.  If the users
+apiVersion: v1
+kind: Service
+metadata:
+  name: knative-local-gateway
+  namespace: istio-system
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  type: ClusterIP
+  selector:
+    istio: ingressgateway
+  ports:
+    - name: http2
+      port: 80
+      targetPort: 8081

--- a/third_party/istio-head/gateway/203-local-gateway.yaml
+++ b/third_party/istio-head/gateway/203-local-gateway.yaml
@@ -22,6 +22,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
+    experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
   type: ClusterIP
   selector:

--- a/third_party/istio-head/gateway/300-gateway-local.yaml
+++ b/third_party/istio-head/gateway/300-gateway-local.yaml
@@ -32,16 +32,3 @@ spec:
           knative-e2e-test: "net-ingressv2-local"
       namespaces:
         from: "All"
-  - protocol: HTTPS
-    port: 443
-    tls:
-      mode: Terminate
-      routeOverride:
-        certificate: Allow
-    routes:
-      kind: HTTPRoute
-      selector:
-        matchLabels:
-          knative-e2e-test: "net-ingressv2-local"
-      namespaces:
-        from: "All"

--- a/third_party/istio-head/gateway/300-gateway-local.yaml
+++ b/third_party/istio-head/gateway/300-gateway-local.yaml
@@ -15,13 +15,13 @@
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: test-gateway
+  name: test-local-gateway
   namespace: istio-system
 spec:
   gatewayClassName: istio
   addresses:
   - type: NamedAddress
-    value: istio-ingressgateway.istio-system.svc.cluster.local
+    value: knative-local-gateway.istio-system.svc.cluster.local
   listeners:
   - protocol: HTTP
     port: 80
@@ -29,7 +29,7 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2"
+          knative-e2e-test: "net-ingressv2-local"
       namespaces:
         from: "All"
   - protocol: HTTPS
@@ -42,6 +42,6 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          knative-e2e-test: "net-ingressv2"
+          knative-e2e-test: "net-ingressv2-local"
       namespaces:
         from: "All"


### PR DESCRIPTION
This patch adds visbility test for istio.

Also, it changes HTTPRoute's Gateway selector to `GatewayAllowAll`
from `GatewayAllowFromList`. (So https://github.com/knative-sandbox/net-ingressv2/pull/47 is also covered eventually.)

/cc @ZhiminXiang @markusthoemmes @howardjohn 