### PR TITLE
Remove workaround of weight 0 test for Istio

### DIFF
--- a/test/conformance/ingressv2/percentage.go
+++ b/test/conformance/ingressv2/percentage.go
@@ -120,10 +120,7 @@ func TestPercentage(t *testing.T) {
 		switch {
 		case want == 0.0 && got > 0.0:
 			// For 0% targets, we have tighter requirements.
-			// t.Errorf("Target %q received traffic, wanted none (0%% target).", name)
-
-			// TODO: Istio does not handle weight 0 correctly. https://github.com/istio/istio/issues/31745
-			t.Skipf("Target %q received traffic, wanted none (0%% target).", name)
+			t.Errorf("Target %q received traffic, wanted none (0%% target).", name)
 		case math.Abs(got-want) > margin:
 			t.Errorf("Target %q received %f%%, wanted %f +/- %f", name, got, want, margin)
 		}

--- a/test/conformance/ingressv2/visibility.go
+++ b/test/conformance/ingressv2/visibility.go
@@ -210,10 +210,7 @@ func TestVisibilitySplit(t *testing.T) {
 		switch {
 		case want == 0.0 && got > 0.0:
 			// For 0% targets, we have tighter requirements.
-			// t.Errorf("Target %q received traffic, wanted none (0%% target).", name)
-
-			// TODO: How weight 0 is handled is not decided yet. https://github.com/kubernetes-sigs/gateway-api/issues/596
-			t.Skipf("Target %q received traffic, wanted none (0%% target).", name)
+			t.Errorf("Target %q received traffic, wanted none (0%% target).", name)
 		case math.Abs(got-want) > margin:
 			t.Errorf("Target %q received %f%%, wanted %f +/- %f", name, got, want, margin)
 		}


### PR DESCRIPTION
Istio had an issue for weight 0 handling as https://github.com/istio/istio/issues/31745
but it was fixed now.

This patch drops the workaround.

/cc @ZhiminXiang 