### PR TITLE
Drop K8s 1.19 as it's no longer supported

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.19.11
         - v1.20.7
         - v1.21.1
+        - v1.22.0
 
         test-suite:
         - ./test/conformance/ingressv2
@@ -31,17 +31,17 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.19.11
-          kind-version: v0.11.1
-          kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
-          ingress: istio
         - k8s-version: v1.20.7
           kind-version: v0.11.1
           kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-          ingress: contour
+          ingress: istio
         - k8s-version: v1.21.1
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          ingress: contour
+        - k8s-version: v1.22.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
           ingress: istio
 
 


### PR DESCRIPTION
It is necessary as knative/pkg#2283 updated.
Same fix with other net repos like https://github.com/knative-sandbox/net-istio/pull/766.

/cc @ZhiminXiang @tcnghia @markusthoemmes 